### PR TITLE
Build restic from source by default

### DIFF
--- a/hack/builddeps.sh
+++ b/hack/builddeps.sh
@@ -2,3 +2,5 @@
 
 # https://github.com/ellisonbg/antipackage
 pip install git+https://github.com/ellisonbg/antipackage.git#egg=antipackage
+
+go get github.com/constabulary/gb/...


### PR DESCRIPTION
To use an officially build version, set env var `RESTIC_VER=0.6.1`