### PR TITLE
Set RESTIC_VER to 0.7.3

### DIFF
--- a/hack/docker/setup.sh
+++ b/hack/docker/setup.sh
@@ -14,7 +14,7 @@ source "$REPO_ROOT/hack/libbuild/common/public_image.sh"
 
 APPSCODE_ENV=${APPSCODE_ENV:-dev}
 IMG=stash
-RESTIC_VER=${RESTIC_VER:-0.7.2}
+RESTIC_VER=${RESTIC_VER:-0.7.3}
 RESTIC_BRANCH=${RESTIC_BRANCH:-stash-0.5.0}
 
 DIST=$REPO_ROOT/dist


### PR DESCRIPTION
Fixes GCS and Azure prune issues:
https://github.com/restic/restic/releases/tag/v0.7.3