### PR TITLE
Fix retentionPolicyName not found error

### DIFF
--- a/apis/stash/v1alpha1/validator.go
+++ b/apis/stash/v1alpha1/validator.go
@@ -8,6 +8,10 @@ import (
 
 func (r Restic) IsValid() error {
 	for i, fg := range r.Spec.FileGroups {
+		if fg.RetentionPolicyName == "" {
+			continue
+		}
+
 		found := false
 		for _, policy := range r.Spec.RetentionPolicies {
 			if policy.Name == fg.RetentionPolicyName {

--- a/test/e2e/deployment_test.go
+++ b/test/e2e/deployment_test.go
@@ -555,4 +555,22 @@ var _ = Describe("Deployment", func() {
 			})
 		})
 	})
+
+	Describe("No retention policy", func() {
+		AfterEach(func() {
+			f.DeleteDeployment(deployment.ObjectMeta)
+			f.DeleteRestic(restic.ObjectMeta)
+			f.DeleteSecret(cred.ObjectMeta)
+		})
+
+		Context(`"Local" backend`, func() {
+			BeforeEach(func() {
+				cred = f.SecretForLocalBackend()
+				restic = f.ResticForLocalBackend()
+				restic.Spec.FileGroups[0].RetentionPolicyName = ""
+				restic.Spec.RetentionPolicies = []api.RetentionPolicy{}
+			})
+			It(`should backup new Deployment`, shouldBackupNewDeployment)
+		})
+	})
 })

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -26,7 +26,7 @@ import (
 
 const (
 	TIMEOUT             = 20 * time.Minute
-	TestSidecarImageTag = "offline-backup"
+	TestSidecarImageTag = "canary"
 )
 
 var (


### PR DESCRIPTION
Fix `retentionPolicyName` not found error when no `spec.fileGroups[].retentionPolicyName` is specified.
N.B. `spec.fileGroups[].retentionPolicyName` is an optional field, user might not specify it if he/she do not want to delete any old snapshots.