### PR TITLE
Use log.LEVEL() instead of fmt.Printf()

### DIFF
--- a/pkg/backup/restic.go
+++ b/pkg/backup/restic.go
@@ -1,8 +1,6 @@
 package backup
 
 import (
-	"fmt"
-
 	"github.com/appscode/go/log"
 	api "github.com/appscode/stash/apis/stash/v1alpha1"
 	stash_listers "github.com/appscode/stash/listers/stash/v1alpha1"
@@ -134,12 +132,12 @@ func (c *Controller) runResticScheduler(key string) error {
 
 	if !exists {
 		// Below we will warm up our cache with a Restic, so that we will see a delete for one d
-		fmt.Printf("Restic %s does not exist anymore\n", key)
+		glog.Warningf("Restic %s does not exist anymore\n", key)
 
 		c.cron.Stop()
 	} else {
 		r := obj.(*api.Restic)
-		fmt.Printf("Sync/Add/Update for Restic %s\n", r.GetName())
+		glog.Infof("Sync/Add/Update for Restic %s\n", r.GetName())
 
 		err := c.configureScheduler(r)
 		if err != nil {

--- a/pkg/controller/daemonsets.go
+++ b/pkg/controller/daemonsets.go
@@ -124,13 +124,13 @@ func (c *StashController) runDaemonSetInjector(key string) error {
 
 	if !exists {
 		// Below we will warm up our cache with a DaemonSet, so that we will see a delete for one d
-		fmt.Printf("DaemonSet %s does not exist anymore\n", key)
+		glog.Warningf("DaemonSet %s does not exist anymore\n", key)
 	} else {
 		ds := obj.(*extensions.DaemonSet)
-		fmt.Printf("Sync/Add/Update for DaemonSet %s\n", ds.GetName())
+		glog.Infof("Sync/Add/Update for DaemonSet %s\n", ds.GetName())
 
 		if util.ToBeInitializedByPeer(ds.Initializers) {
-			fmt.Printf("Not stash's turn to initialize %s\n", ds.GetName())
+			glog.Warningf("Not stash's turn to initialize %s\n", ds.GetName())
 			return nil
 		}
 

--- a/pkg/controller/deployment.go
+++ b/pkg/controller/deployment.go
@@ -124,7 +124,7 @@ func (c *StashController) runDeploymentInjector(key string) error {
 
 	if !exists {
 		// Below we will warm up our cache with a Deployment, so that we will see a delete for one d
-		fmt.Printf("Deployment %s does not exist anymore\n", key)
+		glog.Warningf("Deployment %s does not exist anymore\n", key)
 
 		ns, name, err := cache.SplitMetaNamespaceKey(key)
 		if err != nil {
@@ -133,10 +133,10 @@ func (c *StashController) runDeploymentInjector(key string) error {
 		util.DeleteConfigmapLock(c.k8sClient, ns, api.LocalTypedReference{Kind: api.KindDeployment, Name: name})
 	} else {
 		dp := obj.(*apps.Deployment)
-		fmt.Printf("Sync/Add/Update for Deployment %s\n", dp.GetName())
+		glog.Infof("Sync/Add/Update for Deployment %s\n", dp.GetName())
 
 		if util.ToBeInitializedByPeer(dp.Initializers) {
-			fmt.Printf("Not stash's turn to initialize %s\n", dp.GetName())
+			glog.Warningf("Not stash's turn to initialize %s\n", dp.GetName())
 			return nil
 		}
 

--- a/pkg/controller/jobs.go
+++ b/pkg/controller/jobs.go
@@ -1,8 +1,6 @@
 package controller
 
 import (
-	"fmt"
-
 	"github.com/appscode/go/log"
 	"github.com/appscode/stash/pkg/util"
 	"github.com/golang/glog"
@@ -101,19 +99,19 @@ func (c *StashController) runJobInjector(key string) error {
 		return err
 	}
 	if !exists {
-		fmt.Printf("Job %s does not exist anymore\n", key)
+		glog.Warningf("Job %s does not exist anymore\n", key)
 		return nil
 	} else {
 		job := obj.(*batch.Job)
-		fmt.Printf("Sync/Add/Update for Job %s\n", job.GetName())
+		glog.Infof("Sync/Add/Update for Job %s\n", job.GetName())
 
 		if job.Status.Succeeded > 0 {
-			fmt.Printf("Deleting succeeded job %s\n", job.GetName())
+			glog.Infof("Deleting succeeded job %s\n", job.GetName())
 			if err = util.DeleteStashJob(c.k8sClient, *job); err != nil {
-				fmt.Printf("Failed to delete stash job: %s, reason: %s\n", job.GetName(), err)
+				glog.Errorf("Failed to delete stash job: %s, reason: %s\n", job.GetName(), err)
 				return err
 			}
-			fmt.Printf("Deleted stash job: %s\n", job.GetName())
+			glog.Infof("Deleted stash job: %s\n", job.GetName())
 		}
 	}
 	return nil

--- a/pkg/controller/rcs.go
+++ b/pkg/controller/rcs.go
@@ -122,7 +122,7 @@ func (c *StashController) runRCInjector(key string) error {
 
 	if !exists {
 		// Below we will warm up our cache with a ReplicationController, so that we will see a delete for one d
-		fmt.Printf("ReplicationController %s does not exist anymore\n", key)
+		glog.Warningf("ReplicationController %s does not exist anymore\n", key)
 
 		ns, name, err := cache.SplitMetaNamespaceKey(key)
 		if err != nil {
@@ -131,10 +131,10 @@ func (c *StashController) runRCInjector(key string) error {
 		util.DeleteConfigmapLock(c.k8sClient, ns, api.LocalTypedReference{Kind: api.KindReplicationController, Name: name})
 	} else {
 		rc := obj.(*core.ReplicationController)
-		fmt.Printf("Sync/Add/Update for ReplicationController %s\n", rc.GetName())
+		glog.Infof("Sync/Add/Update for ReplicationController %s\n", rc.GetName())
 
 		if util.ToBeInitializedByPeer(rc.Initializers) {
-			fmt.Printf("Not stash's turn to initialize %s\n", rc.GetName())
+			glog.Warningf("Not stash's turn to initialize %s\n", rc.GetName())
 			return nil
 		}
 

--- a/pkg/controller/recoveries.go
+++ b/pkg/controller/recoveries.go
@@ -152,12 +152,12 @@ func (c *StashController) runRecoveryInjector(key string) error {
 
 	if !exists {
 		// Below we will warm up our cache with a Recovery, so that we will see a delete for one d
-		fmt.Printf("Recovery %s does not exist anymore\n", key)
+		glog.Warningf("Recovery %s does not exist anymore\n", key)
 		return nil
 	}
 
 	d := obj.(*api.Recovery)
-	fmt.Printf("Sync/Add/Update for Recovery %s\n", d.GetName())
+	glog.Infof("Sync/Add/Update for Recovery %s\n", d.GetName())
 	return c.runRecoveryJob(d)
 }
 

--- a/pkg/controller/replicasets.go
+++ b/pkg/controller/replicasets.go
@@ -124,7 +124,7 @@ func (c *StashController) runReplicaSetInjector(key string) error {
 
 	if !exists {
 		// Below we will warm up our cache with a ReplicaSet, so that we will see a delete for one d
-		fmt.Printf("ReplicaSet %s does not exist anymore\n", key)
+		glog.Warningf("ReplicaSet %s does not exist anymore\n", key)
 
 		ns, name, err := cache.SplitMetaNamespaceKey(key)
 		if err != nil {
@@ -133,10 +133,10 @@ func (c *StashController) runReplicaSetInjector(key string) error {
 		util.DeleteConfigmapLock(c.k8sClient, ns, api.LocalTypedReference{Kind: api.KindReplicaSet, Name: name})
 	} else {
 		rs := obj.(*extensions.ReplicaSet)
-		fmt.Printf("Sync/Add/Update for ReplicaSet %s\n", rs.GetName())
+		glog.Infof("Sync/Add/Update for ReplicaSet %s\n", rs.GetName())
 
 		if util.ToBeInitializedByPeer(rs.Initializers) {
-			fmt.Printf("Not stash's turn to initialize %s\n", rs.GetName())
+			glog.Warningf("Not stash's turn to initialize %s\n", rs.GetName())
 			return nil
 		}
 

--- a/pkg/controller/restics.go
+++ b/pkg/controller/restics.go
@@ -158,7 +158,7 @@ func (c *StashController) runResticInjector(key string) error {
 
 	if !exists {
 		// Below we will warm up our cache with a Restic, so that we will see a delete for one d
-		fmt.Printf("Restic %s does not exist anymore\n", key)
+		glog.Warningf("Restic %s does not exist anymore\n", key)
 
 		namespace, name, err := cache.SplitMetaNamespaceKey(key)
 		if err != nil {
@@ -167,7 +167,7 @@ func (c *StashController) runResticInjector(key string) error {
 		c.EnsureSidecarDeleted(namespace, name)
 	} else {
 		restic := obj.(*api.Restic)
-		fmt.Printf("Sync/Add/Update for Restic %s\n", restic.GetName())
+		glog.Infof("Sync/Add/Update for Restic %s\n", restic.GetName())
 
 		if restic.Spec.Type == api.BackupOffline {
 			m := metav1.ObjectMeta{

--- a/pkg/controller/statefulsets.go
+++ b/pkg/controller/statefulsets.go
@@ -124,13 +124,13 @@ func (c *StashController) runStatefulSetInjector(key string) error {
 
 	if !exists {
 		// Below we will warm up our cache with a StatefulSet, so that we will see a delete for one d
-		fmt.Printf("StatefulSet %s does not exist anymore\n", key)
+		glog.Warningf("StatefulSet %s does not exist anymore\n", key)
 	} else {
 		ss := obj.(*apps.StatefulSet)
-		fmt.Printf("Sync/Add/Update for StatefulSet %s\n", ss.GetName())
+		glog.Infof("Sync/Add/Update for StatefulSet %s\n", ss.GetName())
 
 		if util.ToBeInitializedByPeer(ss.Initializers) {
-			fmt.Printf("Not stash's turn to initialize %s\n", ss.GetName())
+			glog.Warningf("Not stash's turn to initialize %s\n", ss.GetName())
 			return nil
 		}
 


### PR DESCRIPTION
Fixes #248.

***

This replaces the `fmt.Printf()` usages with `log.LEVELf()`. I tried to use a level that I found suitable while looking at the lines above and below in the context.