### PR TITLE
Log operator version on start

### DIFF
--- a/pkg/cmds/run.go
+++ b/pkg/cmds/run.go
@@ -73,7 +73,7 @@ func NewCmdRun() *cobra.Command {
 				log.Fatalln(err)
 			}
 
-			log.Infoln("Starting operator...")
+			log.Infof("Starting operator version %s+%s ...", v.Version.Version, v.Version.CommitHash)
 			// Now let's start the controller
 			stop := make(chan struct{})
 			defer close(stop)


### PR DESCRIPTION
This simply adds the version and commit hash to the `Starting operator` log line.

I think it is good to see this information when the operator starts. :)
Let me know what you think.