### PR TITLE
Update Helm chart to use newer 'fullname' template that avoids duplicate (e.g. 'stash-stash-...') resource names

### DIFF
--- a/chart/stable/stash/templates/_helpers.tpl
+++ b/chart/stable/stash/templates/_helpers.tpl
@@ -12,5 +12,9 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 */}}
 {{- define "stash.fullname" -}}
 {{- $name := default .Chart.Name .Values.nameOverride -}}
-{{- printf "%s-%s" $name .Release.Name | trunc 63 -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
 {{- end -}}


### PR DESCRIPTION
The newer 'fullname' go template recommended by `helm create` avoids doubling up on the release/chart name. So it avoids `helm install --name stash stable/stash` leading to resources called `stash-stash-...`. Instead they are called just `stash-...`.

https://github.com/kubernetes/helm/blob/7c79d1c76534074d5708eae2c5ef88ae044941db/pkg/chartutil/create.go#L237-L249