### PR TITLE
Don't block deletion of owner by default

### DIFF
--- a/pkg/util/kubernetes.go
+++ b/pkg/util/kubernetes.go
@@ -588,6 +588,8 @@ func EnsureOwnerReference(meta metav1.ObjectMeta, owner *core.ObjectReference) m
 	meta.OwnerReferences[fi].Kind = owner.Kind
 	meta.OwnerReferences[fi].Name = owner.Name
 	meta.OwnerReferences[fi].UID = owner.UID
-	meta.OwnerReferences[fi].BlockOwnerDeletion = types.TrueP()
+	if meta.OwnerReferences[fi].BlockOwnerDeletion == nil {
+		meta.OwnerReferences[fi].BlockOwnerDeletion = types.FalseP()
+	}
 	return meta
 }


### PR DESCRIPTION
To block deletion of synchronous GC of owner, delete permission on owner is required. We generally do not to want to require delete permission on owner. For background, check here: https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/synchronous-garbage-collection.md#ownerreference