### PR TITLE
Add missing batch jobs get RBAC permission

### DIFF
--- a/pkg/controller/rbac.go
+++ b/pkg/controller/rbac.go
@@ -100,7 +100,7 @@ func (c *StashController) ensureSidecarClusterRole() error {
 			{
 				APIGroups: []string{batch.GroupName},
 				Resources: []string{"jobs"},
-				Verbs:     []string{"create"},
+				Verbs:     []string{"create", "get"},
 			},
 			{
 				APIGroups: []string{rbac.GroupName},


### PR DESCRIPTION
This slipped by my tests as I was still manually creating/applying my RBAC manifests on every operator test run.