### PR TITLE
wip: Added Restic Rest Server backend

### DIFF
--- a/apis/stash/v1alpha1/types.go
+++ b/apis/stash/v1alpha1/types.go
@@ -68,13 +68,13 @@ type FileGroup struct {
 type Backend struct {
 	StorageSecretName string `json:"storageSecretName,omitempty"`
 
-	Local *LocalSpec `json:"local,omitempty"`
-	S3    *S3Spec    `json:"s3,omitempty"`
-	GCS   *GCSSpec   `json:"gcs,omitempty"`
-	Azure *AzureSpec `json:"azure,omitempty"`
-	Swift *SwiftSpec `json:"swift,omitempty"`
-	B2    *B2Spec    `json:"b2,omitempty"`
-	// Rest  *RestServerSpec `json:"rest,omitempty"`
+	Local *LocalSpec      `json:"local,omitempty"`
+	S3    *S3Spec         `json:"s3,omitempty"`
+	GCS   *GCSSpec        `json:"gcs,omitempty"`
+	Azure *AzureSpec      `json:"azure,omitempty"`
+	Swift *SwiftSpec      `json:"swift,omitempty"`
+	B2    *B2Spec         `json:"b2,omitempty"`
+	Rest  *RestServerSpec `json:"rest,omitempty"`
 }
 
 type LocalSpec struct {

--- a/docs/examples/backends/rest/RESTIC_PASSWORD
+++ b/docs/examples/backends/rest/RESTIC_PASSWORD
@@ -1,0 +1,1 @@
+changeit

--- a/docs/examples/backends/rest/REST_SERVER_PASSWORD
+++ b/docs/examples/backends/rest/REST_SERVER_PASSWORD
@@ -1,0 +1,1 @@
+<your-rest-password>

--- a/docs/examples/backends/rest/REST_SERVER_USERNAME
+++ b/docs/examples/backends/rest/REST_SERVER_USERNAME
@@ -1,0 +1,1 @@
+<your-rest-username>

--- a/docs/examples/backends/rest/rest-restic.yaml
+++ b/docs/examples/backends/rest/rest-restic.yaml
@@ -1,0 +1,24 @@
+apiVersion: stash.appscode.com/v1alpha1
+kind: Restic
+metadata:
+  name: rest-restic
+  namespace: default
+spec:
+  selector:
+    matchLabels:
+      app: rest-restic
+  fileGroups:
+  - path: /source/data
+    retentionPolicyName: 'keep-last-5'
+  backend:
+    rest:
+      url: https://example.com
+    storageSecretName: rest-secret
+  schedule: '@every 1m'
+  volumeMounts:
+  - mountPath: /source/data
+    name: source-data
+  retentionPolicies:
+  - name: 'keep-last-5'
+    keepLast: 5
+    prune: true

--- a/docs/examples/backends/rest/rest-secret.yaml
+++ b/docs/examples/backends/rest/rest-secret.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+data:
+  REST_SERVER_USERNAME: PHlvdXItdXNlcm5hbWU+
+  REST_SERVER_PASSWORD: PHlvdXItcGFzc3dvcmQ+
+  RESTIC_PASSWORD: Y2hhbmdlaXQ=
+kind: Secret
+metadata:
+  creationTimestamp: 2017-06-28T13:27:16Z
+  name: rest-secret
+  namespace: default
+  resourceVersion: "6809"
+  selfLink: /api/v1/namespaces/default/secrets/rest-secret
+  uid: 80f658d1-5c05-11e7-bb52-08002711f4aa
+type: Opaque

--- a/pkg/cli/env.go
+++ b/pkg/cli/env.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"fmt"
 	"io/ioutil"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -141,29 +142,20 @@ func (w *ResticWrapper) SetupEnv(backend api.Backend, secret *core.Secret, autoP
 		w.sh.SetEnv(RESTIC_REPOSITORY, r)
 		w.sh.SetEnv(B2_ACCOUNT_ID, string(secret.Data[B2_ACCOUNT_ID]))
 		w.sh.SetEnv(B2_ACCOUNT_KEY, string(secret.Data[B2_ACCOUNT_KEY]))
-		/*
-			} else if backend.Rest != nil {
-				u, err := url.Parse(backend.Rest.URL)
-				if err != nil {
-					return err
-				}
-				if username, ok := secret.Data[REST_SERVER_USERNAME]; ok {
-					if password, ok := secret.Data[REST_SERVER_PASSWORD]; ok {
-						u.User = url.UserPassword(string(username), string(password))
-					} else {
-						u.User = url.User(string(username))
-					}
-				}
-				u.Path = filepath.Join(u.Path, autoPrefix) // TODO: check
-				r := fmt.Sprintf("rest:%s", u.String())
-				w.sh.SetEnv(RESTIC_REPOSITORY, r)
-			} else if backend.B2 != nil {
-				prefix := filepath.Join(backend.B2.Prefix, autoPrefix)
-				r := fmt.Sprintf("b2:%s:%s", backend.B2.Bucket, prefix)
-				w.sh.SetEnv(RESTIC_REPOSITORY, r)
-				w.sh.SetEnv(B2_ACCOUNT_ID, string(secret.Data[B2_ACCOUNT_ID]))
-				w.sh.SetEnv(B2_ACCOUNT_KEY, string(secret.Data[B2_ACCOUNT_KEY]))
-		*/
+	} else if backend.Rest != nil {
+		u, err := url.Parse(backend.Rest.URL)
+		if err != nil {
+			return "", err
+		}
+		if username, ok := secret.Data[REST_SERVER_USERNAME]; ok {
+			if password, ok := secret.Data[REST_SERVER_PASSWORD]; ok {
+				u.User = url.UserPassword(string(username), string(password))
+			} else {
+				u.User = url.User(string(username))
+			}
+		}
+		r := fmt.Sprintf("rest:%s", u.String())
+		w.sh.SetEnv(RESTIC_REPOSITORY, r)
 	}
 
 	return prefix, nil


### PR DESCRIPTION
This kind of re-enables/uncomments the Restic Rest Server backend.

PR has been tested but as discussed in Slack, this "only" works with one sub layer of repositories path.
Example:
Current repo path: `/myownprefix/restic_name/workload/statefulset/test-0`
With rest server only a path such as this would work: `/user` (where `user` means either the workload name or a "real" configured user when separate user repos are turned on in rest server.

Relates #126.