### PR TITLE
Update docs (run minio in v1.9.4+ cluster and add example yaml files in respective backends)

### DIFF
--- a/docs/examples/backends/gcs/gcs-pvc.yaml
+++ b/docs/examples/backends/gcs/gcs-pvc.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: stash-recovered
+  labels:
+    app: stash-demo
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 2Gi

--- a/docs/examples/backends/gcs/gcs-recovery-to-pvc.yaml
+++ b/docs/examples/backends/gcs/gcs-recovery-to-pvc.yaml
@@ -1,7 +1,7 @@
 apiVersion: stash.appscode.com/v1alpha1
 kind: Recovery
 metadata:
-  name: stash-demo
+  name: gcs-recovery
   namespace: default
 spec:
   repository: deployment.stash-demo
@@ -9,5 +9,5 @@ spec:
   - /source/data
   recoveredVolumes:
   - mountPath: /source/data
-    hostPath:
-      path: /data/stash-test/restic-restored
+    persistentVolumeClaim:
+      claimName: stash-recovered

--- a/docs/examples/backends/gcs/gcs-recovery.yaml
+++ b/docs/examples/backends/gcs/gcs-recovery.yaml
@@ -1,7 +1,7 @@
 apiVersion: stash.appscode.com/v1alpha1
 kind: Recovery
 metadata:
-  name: stash-demo
+  name: gcs-recovery
   namespace: default
 spec:
   repository: deployment.stash-demo
@@ -9,5 +9,6 @@ spec:
   - /source/data
   recoveredVolumes:
   - mountPath: /source/data
-    hostPath:
-      path: /data/stash-test/restic-restored
+    gcePersistentDisk:
+        pdName: stash-recovered
+        fsType: ext4

--- a/docs/examples/backends/gcs/gcs-restic.yaml
+++ b/docs/examples/backends/gcs/gcs-restic.yaml
@@ -6,13 +6,13 @@ metadata:
 spec:
   selector:
     matchLabels:
-      app: gcs-restic
+      app: stash-demo
   fileGroups:
   - path: /source/data
     retentionPolicyName: 'keep-last-5'
   backend:
     gcs:
-      bucket: stash-qa
+      bucket: stash-backup-repo
       prefix: demo
     storageSecretName: gcs-secret
   schedule: '@every 1m'

--- a/docs/examples/backends/gcs/restored-deployment-1.yaml
+++ b/docs/examples/backends/gcs/restored-deployment-1.yaml
@@ -1,0 +1,31 @@
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  labels:
+    app: stash-demo
+  name: stash-demo
+  namespace: default
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: stash-demo
+      name: busybox
+    spec:
+      containers:
+      - args:
+        - sleep
+        - "3600"
+        image: busybox
+        imagePullPolicy: IfNotPresent
+        name: busybox
+        volumeMounts:
+        - mountPath: /source/data
+          name: source-data
+      restartPolicy: Always
+      volumes:
+      - name: source-data
+        gcePersistentDisk:
+          pdName: stash-recovered
+          fsType: ext4

--- a/docs/examples/backends/gcs/restored-deployment-2.yaml
+++ b/docs/examples/backends/gcs/restored-deployment-2.yaml
@@ -1,0 +1,30 @@
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  labels:
+    app: stash-demo
+  name: stash-demo
+  namespace: default
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: stash-demo
+      name: busybox
+    spec:
+      containers:
+      - args:
+        - sleep
+        - "3600"
+        image: busybox
+        imagePullPolicy: IfNotPresent
+        name: busybox
+        volumeMounts:
+        - mountPath: /source/data
+          name: source-data
+      restartPolicy: Always
+      volumes:
+      - name: source-data
+        persistentVolumeClaim:
+          claimName: stash-recovered

--- a/docs/examples/backends/minio/minio-deployment.yaml
+++ b/docs/examples/backends/minio/minio-deployment.yaml
@@ -1,0 +1,57 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  # This name uniquely identifies the Deployment
+  name: minio-deployment
+  labels:
+    app: minio
+spec:
+  strategy:
+    type: Recreate # If pod fail, we want to recreate pod rather than restarting it.
+  template:
+    metadata:
+      labels:
+        # Label is used as a selector in the service.
+        app: minio-server
+    spec:
+      volumes:
+      # Refer to the PVC have created earlier
+      - name: storage
+        persistentVolumeClaim:
+          # Name of the PVC created earlier
+          claimName: minio-pvc
+      - name: minio-certs
+        secret:
+          secretName: minio-server-secret
+          items:
+          - key: public.crt
+            path: public.crt
+          - key: private.key
+            path: private.key
+          - key: public.crt
+            path: CAs/public.crt # mark self signed certificate as trusted
+      containers:
+      - name: minio
+        # Pulls the default Minio image from Docker Hub
+        image: minio/minio
+        args:
+        - server
+        - --address
+        - ":443"
+        - /storage
+        env:
+        # Minio access key and secret key
+        - name: MINIO_ACCESS_KEY
+          value: "<your minio access key(any string)>"
+        - name: MINIO_SECRET_KEY
+          value: "<your minio secret key(any string)>"
+        ports:
+        - containerPort: 443
+          # This ensures containers are allocated on separate hosts. Remove hostPort to allow multiple Minio containers on one host
+          hostPort: 443
+        # Mount the volumes into the pod
+        volumeMounts:
+        - name: storage # must match the volume name, above
+          mountPath: "/storage"
+        - name: minio-certs
+          mountPath: "/root/.minio/certs"

--- a/docs/examples/backends/minio/minio-pvc.yaml
+++ b/docs/examples/backends/minio/minio-pvc.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  # This name uniquely identifies the PVC. Will be used in minio deployment.
+  name: minio-pvc
+  labels:
+    app: minio
+spec:
+  storageClassName: standard
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    # This is the request for storage. Should be available in the cluster.
+    requests:
+      storage: 2Gi

--- a/docs/examples/backends/minio/minio-service.yaml
+++ b/docs/examples/backends/minio/minio-service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: minio-service
+  labels:
+    app: minio
+spec:
+  type: LoadBalancer
+  ports:
+    - port: 443
+      targetPort: 443
+      protocol: TCP
+  selector:
+    app: minio-server # must match with the label used in the deployment

--- a/docs/examples/backends/rook/restored-deployment.yaml
+++ b/docs/examples/backends/rook/restored-deployment.yaml
@@ -1,0 +1,30 @@
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  labels:
+    app: stash-demo
+  name: stash-demo
+  namespace: default
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: stash-demo
+      name: busybox
+    spec:
+      containers:
+      - args:
+        - sleep
+        - "3600"
+        image: busybox
+        imagePullPolicy: IfNotPresent
+        name: busybox
+        volumeMounts:
+        - mountPath: /source/data
+          name: source-data
+      restartPolicy: Always
+      volumes:
+      - name: source-data
+        persistentVolumeClaim:
+          claimName: stash-recovered

--- a/docs/examples/backends/rook/rook-pvc.yaml
+++ b/docs/examples/backends/rook/rook-pvc.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: stash-recovered
+  labels:
+    app: stash-demo
+spec:
+  storageClassName: rook-block
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 2Gi

--- a/docs/examples/backends/rook/rook-recovery.yaml
+++ b/docs/examples/backends/rook/rook-recovery.yaml
@@ -1,7 +1,7 @@
 apiVersion: stash.appscode.com/v1alpha1
 kind: Recovery
 metadata:
-  name: stash-demo
+  name: rook-recovery
   namespace: default
 spec:
   repository: deployment.stash-demo
@@ -9,5 +9,5 @@ spec:
   - /source/data
   recoveredVolumes:
   - mountPath: /source/data
-    hostPath:
-      path: /data/stash-test/restic-restored
+    persistentVolumeClaim:
+      claimName: stash-recovered

--- a/docs/examples/backends/rook/rook-restic.yaml
+++ b/docs/examples/backends/rook/rook-restic.yaml
@@ -1,7 +1,7 @@
 apiVersion: stash.appscode.com/v1alpha1
 kind: Restic
 metadata:
-  name: minio-restic
+  name: rook-restic
   namespace: default
 spec:
   selector:
@@ -12,10 +12,10 @@ spec:
     retentionPolicyName: 'keep-last-5'
   backend:
     s3:
-      endpoint: 'https://minio-service.default.svc' # Use your own Minio server address.
-      bucket: stash-qa  # Give a name of the bucket where you want to backup.
+      endpoint: 'http://rook-ceph-rgw-my-store.rook' # Use your own rook object storage end point.
+      bucket: stash-backup  # Give a name of the bucket where you want to backup.
       prefix: demo  # . Path prefix into bucket where repository will be created.(optional).
-    storageSecretName: minio-restic-secret
+    storageSecretName: rook-restic-secret
   schedule: '@every 1m'
   volumeMounts:
   - mountPath: /source/data

--- a/docs/examples/tutorial/recovery-specific-snapshot.yaml
+++ b/docs/examples/tutorial/recovery-specific-snapshot.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: default
 spec:
   repository: deployment.stash-demo
+  snapshot: deployment.stash-demo-d3050010
   paths:
   - /source/data
   recoveredVolumes:

--- a/docs/guides/gke.md
+++ b/docs/guides/gke.md
@@ -11,6 +11,7 @@ You should have understanding the following Stash concepts:
 - [Restic](/docs/concepts/crds/restic.md)
 - [Repository](/docs/concepts/crds/repository.md)
 - [Recovery](/docs/concepts/crds/recovery.md)
+- [Snapshot](/docs/concepts/crds/snapshot.md)
 
 Then, you will need to have a [GCS Bucket](https://console.cloud.google.com/storage) and [GCE persistent disk](https://console.cloud.google.com/compute/disks). GCE persistent disk must be in the same GCE project and zone as the cluster.
 
@@ -19,7 +20,7 @@ Then, you will need to have a [GCS Bucket](https://console.cloud.google.com/stor
 First, deploy the following `busybox` Deployment in your cluster. Here we are using a git repository as a source volume for demonstration purpose.
 
 ```console
-$ kubectl apply -f ./busybox.yaml
+$ kubectl apply -f ./docs/examples/tutorial/busybox.yaml
 deployment "stash-demo" created
 ```
 
@@ -120,7 +121,7 @@ type: Opaque
 Now, we can create `Restic` crd. This will create a repository `stash-backup-repo` in GCS bucket and start taking periodic backup of `/source/data/` folder.
 
 ```console
-$ kubectl apply -f ./gcs-restic.yaml
+$ kubectl apply -f ./docs/examples/backends/gcs/gcs-restic.yaml
 restic "gcs-restic" created
 ```
 
@@ -176,7 +177,7 @@ Here, `deployment.stash-demo-c1014ca6` represents the name of the successful bac
 Now, we will recover the backed up data into GCE persistent disk. First create a GCE disk named `stash-recovered` from [Google cloud console](https://console.cloud.google.com/compute/disks). Then create `Recovery` crd,
 
 ```console
-$ kubectl apply -f ./gcs-recovery.yaml
+$ kubectl apply -f ./docs/examples/backends/gcs/gcs-recovery.yaml
 recovery "gcs-recovery" created
 ```
 
@@ -255,7 +256,7 @@ recovery "gcs-recovery" deleted
 Now, mount the recovered volume in `busybox` deployment instead of `gitRepo` we had mounted before then re-deploy it.
 
 ```console
-$ kubectl apply -f ./busybox.yaml
+$ kubectl apply -f ./docs/examples/backends/gcs/restored-deployment-1.yaml
 deployment "stash-demo" created
 ```
 
@@ -330,7 +331,7 @@ restic "rook-restic" deleted
 Now, create a `PersistentVolumeClaim`,
 
 ```console
-$ kubectl apply -f ./gcs-pvc.yaml
+$ kubectl apply -f ./docs/examples/backends/gcs/gcs-pvc.yaml
 persistentvolumeclaim "stash-recovered" created
 ```
 
@@ -364,7 +365,7 @@ Look at the `STATUS` filed. `stash-recovered` PVC is bounded to volume `pvc-57be
 Now, create a `Recovery` to recover backed up data in this PVC.
 
 ```console
-$ kubectl apply -f ./gcs-recovery-pvc.yaml
+$ kubectl apply -f ./docs/examples/backends/gcs/gcs-recovery-to-pvc.yaml
 recovery "gcs-recovery" created
 ```
 
@@ -432,7 +433,7 @@ recovery "gcs-recovery" deleted
 Now, mount the recovered `PersistentVolumeClaim` in `busybox` deployment instead of `gitRepo` we had mounted before then re-deploy it,
 
 ```console
-$ kubectl apply -f ./busybox.yaml
+$ kubectl apply -f ./docs/examples/backends/gcs/restored-deployment-2.yaml
 deployment "stash-demo" created
 ```
 

--- a/docs/guides/minio_server.md
+++ b/docs/guides/minio_server.md
@@ -122,7 +122,7 @@ type: Opaque
 Minio server needs a Persistent Volume to store data. Let's create a `Persistent Volume Claim` to request Persistent Volume from the cluster.
 
 ```console
-$ kubectl apply -f ./minio-pvc.yaml
+$ kubectl apply -f ./docs/examples/backends/minio/minio-pvc.yaml
 persistentvolumeclaim "minio-pvc" created
 ```
 
@@ -151,7 +151,7 @@ spec:
 Minio deployment creates pod where the Minio server will run. Let's create a deployment for minio server by,
 
 ```console
-$ kubectl apply -f ./minio-deployment.yaml
+$ kubectl apply -f ./docs/examples/backends/minio/minio-deployment.yaml
 deployment "minio-deployment" created
 ```
 
@@ -222,7 +222,7 @@ spec:
 Now, the final touch. Minio server is running in the cluster. Let's create a service so that other pods can access the server.
 
 ```console
-$ kubectl apply -f ./minio-service.yaml
+$ kubectl apply -f ./docs/examples/backends/minio/minio-service.yaml
 service "minio-service" created
 ```
 
@@ -262,7 +262,7 @@ In this tutorial, we are going to backup the `/source/data` folder of a `busybox
 First, deploy the following `busybox` Deployment in your cluster. Here we are using a git repository as a source volume for demonstration purpose.
 
 ```console
-$  kubectl apply -f ./busybox.yaml
+$  kubectl apply -f ./docs/examples/tutorial/busybox.yaml
 deployment "stash-demo" created
 ```
 
@@ -375,7 +375,7 @@ type: Opaque
 Now, we can create `Restic` crd. This will create a repository in Minio server and start taking periodic backup of `/source/data/` folder.
 
 ```console
-$ kubectl apply -f ./minio-restic.yaml
+$ kubectl apply -f ./docs/examples/backends/minio/minio-restic.yaml
 restic "minio-restic" created
 ```
 
@@ -440,7 +440,7 @@ restic "minio-restic" deleted
 Now, create a  `Recovery` crd.
 
 ```console
-$ kubectl apply -f ./minio-recovery.yaml
+$ kubectl apply -f ./docs/examples/backends/minio/minio-recovery.yaml
 recovery "minio-recovery" created
 ```
 

--- a/docs/guides/restore.md
+++ b/docs/guides/restore.md
@@ -96,7 +96,7 @@ deployment.stash-demo-3e79020e   35s
 Now, create a `Recovery` with specifying `Snapshot` name,
 
 ```console
-$ kubectl apply -f ./docs/examples/tutorial/recovery.yaml
+$ kubectl apply -f ./docs/examples/tutorial/recovery-specific-snapshot.yaml
 recovery "stash-demo" created
 ```
 

--- a/docs/guides/rook.md
+++ b/docs/guides/rook.md
@@ -11,6 +11,7 @@ You should have understanding the following Stash concepts:
 - [Restic](/docs/concepts/crds/restic.md)
 - [Repository](/docs/concepts/crds/repository.md)
 - [Recovery](/docs/concepts/crds/recovery.md)
+- [Snapshot](/docs/concepts/crds/snapshot.md)
 
 Then, you will need to have a [Rook Storage Service](https://rook.io) with [Object Storage](https://rook.io/docs/rook/master/object.html) and [Block Storage](https://rook.io/docs/rook/master/block.html) configured. If you do not already have a **Rook Storage Service** configured, you can create one by following this [quickstart guide](https://rook.io/docs/rook/master/quickstart.html).
 
@@ -19,7 +20,7 @@ Then, you will need to have a [Rook Storage Service](https://rook.io) with [Obje
 First, deploy the following `busybox` Deployment in your cluster. Here we are using a git repository as a source volume for demonstration purpose.
 
 ```console
-$ kubectl apply -f ./busybox.yaml
+$ kubectl apply -f ./docs/examples/tutorial/busybox.yaml
 deployment "stash-demo" created
 ```
 
@@ -120,7 +121,7 @@ type: Opaque
 Now, we can create `Restic` crd. This will create a repository `stash-backup-repo` in **Rook Object Storage** bucket and start taking periodic backup of `/source/data/` folder.
 
 ```console
-$ kubectl apply -f ./rook-restic.yaml
+$ kubectl apply -f ./docs/examples/backends/rook/rook-restic.yaml
 restic "rook-restic" created
 ```
 
@@ -187,7 +188,7 @@ restic "rook-restic" deleted
 Now, create a `PersistentVolumeClaim` for Rook Block Storage,
 
 ```console
-$ kubectl apply -f ./rook-pvc.yaml
+$ kubectl apply -f ./docs/examples/backends/rook/rook-pvc.yaml
 persistentvolumeclaim "stash-recovered" created
 ```
 
@@ -222,7 +223,7 @@ Look at the `STATUS` filed. `stash-recovered` PVC is bounded to volume `pvc-a7aa
 Now, create a `Recovery` to recover backed up data in this PVC.
 
 ```console
-$ kubectl apply -f ./rook-recovery.yaml
+$ kubectl apply -f ./docs/examples/backends/rook/rook-recovery.yaml
 recovery "rook-recovery" created
 ```
 
@@ -290,7 +291,7 @@ recovery "rook-recovery" deleted
 Now, mount the recovered `PersistentVolumeClaim` in `busybox` deployment instead of `gitRepo` we had mounted before then re-deploy it,
 
 ```console
-$ kubectl apply -f ./busybox.yaml
+$ kubectl apply -f ./docs/examples/backends/rook/restored-deployment.yaml
 deployment "stash-demo" created
 ```
 

--- a/test/e2e/framework/minio_server.go
+++ b/test/e2e/framework/minio_server.go
@@ -145,7 +145,7 @@ func (fi *Invocation) DeploymentForMinioServer() apps.Deployment {
 							},
 						},
 						{
-							Name: "minio-public-crt",
+							Name: "minio-certs",
 							VolumeSource: core.VolumeSource{
 								Secret: &core.SecretVolumeSource{
 									SecretName: "minio-server-secret",
@@ -154,33 +154,13 @@ func (fi *Invocation) DeploymentForMinioServer() apps.Deployment {
 											Key:  MINIO_PUBLIC_CRT_NAME,
 											Path: MINIO_PUBLIC_CRT_NAME,
 										},
-									},
-								},
-							},
-						},
-						{
-							Name: "minio-private-key",
-							VolumeSource: core.VolumeSource{
-								Secret: &core.SecretVolumeSource{
-									SecretName: "minio-server-secret",
-									Items: []core.KeyToPath{
 										{
 											Key:  MINIO_PRIVATE_KEY_NAME,
 											Path: MINIO_PRIVATE_KEY_NAME,
 										},
-									},
-								},
-							},
-						},
-						{
-							Name: "minio-ca-crt",
-							VolumeSource: core.VolumeSource{
-								Secret: &core.SecretVolumeSource{
-									SecretName: "minio-server-secret",
-									Items: []core.KeyToPath{
 										{
 											Key:  MINIO_PUBLIC_CRT_NAME,
-											Path: MINIO_PUBLIC_CRT_NAME,
+											Path: filepath.Join("CAs", MINIO_PUBLIC_CRT_NAME),
 										},
 									},
 								},
@@ -220,19 +200,8 @@ func (fi *Invocation) DeploymentForMinioServer() apps.Deployment {
 									MountPath: "/storage",
 								},
 								{
-									Name:      "minio-public-crt",
-									MountPath: filepath.Join(MINIO_CERTS_MOUNTPATH, MINIO_PUBLIC_CRT_NAME),
-									SubPath:   MINIO_PUBLIC_CRT_NAME,
-								},
-								{
-									Name:      "minio-private-key",
-									MountPath: filepath.Join(MINIO_CERTS_MOUNTPATH, MINIO_PRIVATE_KEY_NAME),
-									SubPath:   MINIO_PRIVATE_KEY_NAME,
-								},
-								{
-									Name:      "minio-ca-crt",
-									MountPath: filepath.Join(MINIO_CERTS_MOUNTPATH, "CAs", MINIO_PUBLIC_CRT_NAME),
-									SubPath:   MINIO_PUBLIC_CRT_NAME,
+									Name:      "minio-certs",
+									MountPath: MINIO_CERTS_MOUNTPATH,
 								},
 							},
 						},


### PR DESCRIPTION
This PR fixes #467 

Change log:
- [x] Update minio doc to run minio server in v1.9.4 and later cluster
- [x]  Add  example yaml files in respective backends
- [x] Update docs with respective file yaml locations