### PR TITLE
Add support for initial backoff to the apiserver call on recover

### DIFF
--- a/docs/reference/stash_recover.md
+++ b/docs/reference/stash_recover.md
@@ -24,10 +24,11 @@ stash recover [flags]
 ### Options
 
 ```
-  -h, --help                   help for recover
-      --kubeconfig string      Path to kubeconfig file with authorization information (the master location is set by the master flag).
-      --master string          The address of the Kubernetes API server (overrides any value in kubeconfig)
-      --recovery-name string   Name of the Recovery CRD.
+      --backoff-max-wait duration   Maximum wait for initial response from kube apiserver; 0 disables the timeout
+  -h, --help                        help for recover
+      --kubeconfig string           Path to kubeconfig file with authorization information (the master location is set by the master flag).
+      --master string               The address of the Kubernetes API server (overrides any value in kubeconfig)
+      --recovery-name string        Name of the Recovery CRD.
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/stash_run.md
+++ b/docs/reference/stash_run.md
@@ -24,27 +24,35 @@ stash run [flags]
 ### Options
 
 ```
+      --audit-log-batch-buffer-size int                         The size of the buffer to store events before batching and writing. Only used in batch mode. (default 10000)
+      --audit-log-batch-max-size int                            The maximum size of a batch. Only used in batch mode. (default 400)
+      --audit-log-batch-max-wait duration                       The amount of time to wait before force writing the batch that hadn't reached the max size. Only used in batch mode. (default 30s)
+      --audit-log-batch-throttle-burst int                      Maximum number of requests sent at the same moment if ThrottleQPS was not utilized before. Only used in batch mode. (default 15)
+      --audit-log-batch-throttle-enable                         Whether batching throttling is enabled. Only used in batch mode.
+      --audit-log-batch-throttle-qps float32                    Maximum average number of batches per second. Only used in batch mode. (default 10)
       --audit-log-format string                                 Format of saved audits. "legacy" indicates 1-line text format for each event. "json" indicates structured json format. Requires the 'AdvancedAuditing' feature gate. Known formats are legacy,json. (default "json")
       --audit-log-maxage int                                    The maximum number of days to retain old audit log files based on the timestamp encoded in their filename.
       --audit-log-maxbackup int                                 The maximum number of old audit log files to retain.
       --audit-log-maxsize int                                   The maximum size in megabytes of the audit log file before it gets rotated.
+      --audit-log-mode string                                   Strategy for sending audit events. Blocking indicates sending events should block server responses. Batch causes the backend to buffer and write events asynchronously. Known modes are batch,blocking. (default "blocking")
       --audit-log-path string                                   If set, all requests coming to the apiserver will be logged to this file.  '-' means standard out.
       --audit-policy-file string                                Path to the file that defines the audit policy configuration. Requires the 'AdvancedAuditing' feature gate. With AdvancedAuditing, a profile is required to enable auditing.
-      --audit-webhook-batch-buffer-size int                     The size of the buffer to store events before batching and sending to the webhook. Only used in batch mode. (default 10000)
-      --audit-webhook-batch-initial-backoff duration            The amount of time to wait before retrying the first failed requests. Only used in batch mode. (default 10s)
-      --audit-webhook-batch-max-size int                        The maximum size of a batch sent to the webhook. Only used in batch mode. (default 400)
-      --audit-webhook-batch-max-wait duration                   The amount of time to wait before force sending the batch that hadn't reached the max size. Only used in batch mode. (default 30s)
+      --audit-webhook-batch-buffer-size int                     The size of the buffer to store events before batching and writing. Only used in batch mode. (default 10000)
+      --audit-webhook-batch-max-size int                        The maximum size of a batch. Only used in batch mode. (default 400)
+      --audit-webhook-batch-max-wait duration                   The amount of time to wait before force writing the batch that hadn't reached the max size. Only used in batch mode. (default 30s)
       --audit-webhook-batch-throttle-burst int                  Maximum number of requests sent at the same moment if ThrottleQPS was not utilized before. Only used in batch mode. (default 15)
-      --audit-webhook-batch-throttle-qps float32                Maximum average number of requests per second. Only used in batch mode. (default 10)
+      --audit-webhook-batch-throttle-enable                     Whether batching throttling is enabled. Only used in batch mode. (default true)
+      --audit-webhook-batch-throttle-qps float32                Maximum average number of batches per second. Only used in batch mode. (default 10)
       --audit-webhook-config-file string                        Path to a kubeconfig formatted file that defines the audit webhook configuration. Requires the 'AdvancedAuditing' feature gate.
-      --audit-webhook-mode string                               Strategy for sending audit events. Blocking indicates sending events should block server responses. Batch causes the webhook to buffer and send events asynchronously. Known modes are batch,blocking. (default "batch")
+      --audit-webhook-initial-backoff duration                  The amount of time to wait before retrying the first failed request. (default 10s)
+      --audit-webhook-mode string                               Strategy for sending audit events. Blocking indicates sending events should block server responses. Batch causes the backend to buffer and write events asynchronously. Known modes are batch,blocking. (default "batch")
       --authentication-kubeconfig string                        kubeconfig file pointing at the 'core' kubernetes server with enough rights to create tokenaccessreviews.authentication.k8s.io.
       --authentication-skip-lookup                              If false, the authentication-kubeconfig will be used to lookup missing authentication configuration from the cluster.
       --authentication-token-webhook-cache-ttl duration         The duration to cache responses from the webhook token authenticator. (default 10s)
       --authorization-kubeconfig string                         kubeconfig file pointing at the 'core' kubernetes server with enough rights to create  subjectaccessreviews.authorization.k8s.io.
       --authorization-webhook-cache-authorized-ttl duration     The duration to cache 'authorized' responses from the webhook authorizer. (default 10s)
       --authorization-webhook-cache-unauthorized-ttl duration   The duration to cache 'unauthorized' responses from the webhook authorizer. (default 10s)
-      --bind-address ip                                         The IP address on which to listen for the --secure-port port. The associated interface(s) must be reachable by the rest of the cluster, and by CLI/web clients. If blank, all interfaces will be used (0.0.0.0). (default 0.0.0.0)
+      --bind-address ip                                         The IP address on which to listen for the --secure-port port. The associated interface(s) must be reachable by the rest of the cluster, and by CLI/web clients. If blank, all interfaces will be used (0.0.0.0 for all IPv4 interfaces and :: for all IPv6 interfaces). (default 0.0.0.0)
       --burst int                                               The maximum burst for throttle (default 100)
       --cert-dir string                                         The directory where the TLS certs are located. If --tls-cert-file and --tls-private-key-file are provided, this flag will be ignored. (default "apiserver.local.config/certificates")
       --client-ca-file string                                   If set, any request presenting a client certificate signed by one of the authorities in the client-ca-file is authenticated with an identity corresponding to the CommonName of the client certificate.
@@ -52,6 +60,7 @@ stash run [flags]
       --docker-registry string                                  Docker image registry for sidecar, init-container, check-job, recovery-job and kubectl-job (default "appscode")
       --enable-swagger-ui                                       Enables swagger ui on the apiserver at /swagger-ui
   -h, --help                                                    help for run
+      --http2-max-streams-per-connection int                    The limit that the server gives to clients for the maximum number of streams in an HTTP/2 connection. Zero means to use golang's default. (default 1000)
       --image-tag string                                        Image tag for sidecar, init-container, check-job and recovery-job (default "canary")
       --kubeconfig string                                       kubeconfig file pointing at the 'core' kubernetes server.
       --ops-address string                                      Address to listen on for web interface and telemetry. (default ":56790")
@@ -66,8 +75,9 @@ stash run [flags]
       --resync-period duration                                  If non-zero, will re-list this often. Otherwise, re-list will be delayed aslong as possible (until the upstream source closes the watch or times out. (default 10m0s)
       --scratch-dir emptyDir                                    Directory used to store temporary files. Use an emptyDir in Kubernetes. (default "/tmp")
       --secure-port int                                         The port on which to serve HTTPS with authentication and authorization. If 0, don't serve HTTPS at all. (default 443)
-      --tls-ca-file string                                      If set, this certificate authority will used for secure access from Admission Controllers. This must be a valid PEM-encoded CA bundle. Altneratively, the certificate authority can be appended to the certificate provided by --tls-cert-file.
       --tls-cert-file string                                    File containing the default x509 Certificate for HTTPS. (CA cert, if any, concatenated after server cert). If HTTPS serving is enabled, and --tls-cert-file and --tls-private-key-file are not provided, a self-signed certificate and key are generated for the public address and saved to the directory specified by --cert-dir.
+      --tls-cipher-suites strings                               Comma-separated list of cipher suites for the server. Values are from tls package constants (https://golang.org/pkg/crypto/tls/#pkg-constants). If omitted, the default Go cipher suites will be used
+      --tls-min-version string                                  Minimum TLS version supported. Value must match version names from https://golang.org/pkg/crypto/tls/#pkg-constants.
       --tls-private-key-file string                             File containing the default x509 private key matching --tls-cert-file.
       --tls-sni-cert-key namedCertKey                           A pair of x509 certificate and private key file paths, optionally suffixed with a list of domain patterns which are fully qualified domain names, possibly with prefixed wildcard segments. If no domain patterns are provided, the names of the certificate are extracted. Non-wildcard matches trump over wildcard matches, explicit domain patterns trump over extracted names. For multiple key/certificate pairs, use the --tls-sni-cert-key multiple times. Examples: "example.crt,example.key" or "foo.crt,foo.key:*.foo.com,foo.com". (default [])
 ```

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 2642afa5e9ad2683b7cafc3530162db7134e0d11c36e1e451d6dda2b7f01ea37
-updated: 2018-05-05T12:08:12.368959344-07:00
+hash: 34cb79f018183b9dd19b4ab6f07ec4f03ff1299b72671bbd6182a6e663ff70ef
+updated: 2018-05-16T14:23:55.846658679-07:00
 imports:
 - name: bitbucket.org/ww/goautoneg
   version: 75cd24fc2f2c2a2088577d12123ddee5f54e0675
@@ -39,7 +39,7 @@ imports:
   - registry/admissionreview/v1beta1
   - runtime/serializer/versioning
 - name: github.com/appscode/kutil
-  version: ed8d181d523ddd37e5cb7a23fa457b4c370a5140
+  version: c397449684de5caf2de0309e6453eab905901cf8
   subpackages:
   - apiextensions/v1beta1
   - apps/v1beta1
@@ -112,7 +112,7 @@ imports:
 - name: github.com/blang/semver
   version: b38d23b8782a487059e8fc8773e9a5b228a77cb6
 - name: github.com/cenkalti/backoff
-  version: 61153c768f31ee5f130071d08fc82b85208528de
+  version: 2ea60e5f094469f9e65adb9cd103795b73ae743e
 - name: github.com/codegangsta/inject
   version: 33e0aa1cb7c019ccc3fbe049a8262a6403d30504
 - name: github.com/codeskyblue/go-sh
@@ -509,7 +509,7 @@ imports:
   subpackages:
   - rate
 - name: google.golang.org/api
-  version: db8ef494b6bdaf472489f97ad9c556e18c963444
+  version: d7aa31fbd7da4467a8056610e654315a4c1f068e
   subpackages:
   - gensupport
   - googleapi
@@ -932,7 +932,7 @@ imports:
   - pkg/client/clientset_generated/clientset/typed/apiregistration/v1
   - pkg/client/clientset_generated/clientset/typed/apiregistration/v1beta1
 - name: k8s.io/kube-openapi
-  version: f08db293d3ef80052d6513ece19792642a289fea
+  version: b3f03f55328800731ce03a164b80973014ecd455
   subpackages:
   - pkg/builder
   - pkg/common

--- a/glide.yaml
+++ b/glide.yaml
@@ -4,7 +4,7 @@ import:
   version: master
 - package: github.com/appscode/pat
 - package: github.com/cenkalti/backoff
-  version: v1.1.0
+  version: v2.0.0
 - package: github.com/codeskyblue/go-sh
   version: master
 - package: github.com/golang/glog

--- a/pkg/cmds/recover.go
+++ b/pkg/cmds/recover.go
@@ -17,7 +17,7 @@ func NewCmdRecover() *cobra.Command {
 		masterURL      string
 		kubeconfigPath string
 		recoveryName   string
-		backoffMaxWait int
+		backoffMaxWait time.Duration
 	)
 
 	cmd := &cobra.Command{
@@ -32,14 +32,14 @@ func NewCmdRecover() *cobra.Command {
 			kubeClient := kubernetes.NewForConfigOrDie(config)
 			stashClient := cs.NewForConfigOrDie(config)
 
-			c := recovery.New(kubeClient, stashClient, meta.Namespace(), recoveryName, time.Duration(backoffMaxWait)*time.Second)
+			c := recovery.New(kubeClient, stashClient, meta.Namespace(), recoveryName, backoffMaxWait)
 			c.Run()
 		},
 	}
 	cmd.Flags().StringVar(&masterURL, "master", masterURL, "The address of the Kubernetes API server (overrides any value in kubeconfig)")
 	cmd.Flags().StringVar(&kubeconfigPath, "kubeconfig", kubeconfigPath, "Path to kubeconfig file with authorization information (the master location is set by the master flag).")
 	cmd.Flags().StringVar(&recoveryName, "recovery-name", recoveryName, "Name of the Recovery CRD.")
-	cmd.Flags().IntVar(&backoffMaxWait, "backoff-max-wait", 0, "Maximum wait in seconds for initial response from apiserver; 0 disables the timeout")
+	cmd.Flags().DurationVar(&backoffMaxWait, "backoff-max-wait", 0, "Maximum wait for initial response from kube apiserver; 0 disables the timeout")
 
 	return cmd
 }

--- a/pkg/cmds/recover.go
+++ b/pkg/cmds/recover.go
@@ -1,6 +1,8 @@
 package cmds
 
 import (
+	"time"
+
 	"github.com/appscode/go/log"
 	"github.com/appscode/kutil/meta"
 	cs "github.com/appscode/stash/client/clientset/versioned/typed/stash/v1alpha1"
@@ -15,6 +17,7 @@ func NewCmdRecover() *cobra.Command {
 		masterURL      string
 		kubeconfigPath string
 		recoveryName   string
+		backoffMaxWait int
 	)
 
 	cmd := &cobra.Command{
@@ -29,13 +32,14 @@ func NewCmdRecover() *cobra.Command {
 			kubeClient := kubernetes.NewForConfigOrDie(config)
 			stashClient := cs.NewForConfigOrDie(config)
 
-			c := recovery.New(kubeClient, stashClient, meta.Namespace(), recoveryName)
+			c := recovery.New(kubeClient, stashClient, meta.Namespace(), recoveryName, time.Duration(backoffMaxWait)*time.Second)
 			c.Run()
 		},
 	}
 	cmd.Flags().StringVar(&masterURL, "master", masterURL, "The address of the Kubernetes API server (overrides any value in kubeconfig)")
 	cmd.Flags().StringVar(&kubeconfigPath, "kubeconfig", kubeconfigPath, "Path to kubeconfig file with authorization information (the master location is set by the master flag).")
 	cmd.Flags().StringVar(&recoveryName, "recovery-name", recoveryName, "Name of the Recovery CRD.")
+	cmd.Flags().IntVar(&backoffMaxWait, "backoff-max-wait", 0, "Maximum wait in seconds for initial response from apiserver; 0 disables the timeout")
 
 	return cmd
 }

--- a/vendor/github.com/appscode/kutil/apps/v1beta1/kubernetes.go
+++ b/vendor/github.com/appscode/kutil/apps/v1beta1/kubernetes.go
@@ -1,35 +1,7 @@
 package v1beta1
 
 import (
-	"github.com/appscode/kutil/meta"
 	"github.com/json-iterator/go"
-	"github.com/pkg/errors"
-	apps "k8s.io/api/apps/v1beta1"
-	"k8s.io/apimachinery/pkg/conversion"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 var json = jsoniter.ConfigFastest
-
-func GetGroupVersionKind(v interface{}) schema.GroupVersionKind {
-	return apps.SchemeGroupVersion.WithKind(meta.GetKind(v))
-}
-
-func AssignTypeKind(v interface{}) error {
-	_, err := conversion.EnforcePtr(v)
-	if err != nil {
-		return err
-	}
-
-	switch u := v.(type) {
-	case *apps.StatefulSet:
-		u.APIVersion = apps.SchemeGroupVersion.String()
-		u.Kind = meta.GetKind(v)
-		return nil
-	case *apps.Deployment:
-		u.APIVersion = apps.SchemeGroupVersion.String()
-		u.Kind = meta.GetKind(v)
-		return nil
-	}
-	return errors.New("unknown v1beta1 object type")
-}

--- a/vendor/github.com/appscode/kutil/batch/v1beta1/kubernetes.go
+++ b/vendor/github.com/appscode/kutil/batch/v1beta1/kubernetes.go
@@ -1,31 +1,7 @@
 package v1beta1
 
 import (
-	"github.com/appscode/kutil/meta"
 	"github.com/json-iterator/go"
-	"github.com/pkg/errors"
-	batch "k8s.io/api/batch/v1beta1"
-	"k8s.io/apimachinery/pkg/conversion"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 var json = jsoniter.ConfigFastest
-
-func GetGroupVersionKind(v interface{}) schema.GroupVersionKind {
-	return batch.SchemeGroupVersion.WithKind(meta.GetKind(v))
-}
-
-func AssignTypeKind(v interface{}) error {
-	_, err := conversion.EnforcePtr(v)
-	if err != nil {
-		return err
-	}
-
-	switch u := v.(type) {
-	case *batch.CronJob:
-		u.APIVersion = batch.SchemeGroupVersion.String()
-		u.Kind = meta.GetKind(v)
-		return nil
-	}
-	return errors.New("unknown v1beta1 object type")
-}

--- a/vendor/github.com/appscode/kutil/core/v1/kubernetes.go
+++ b/vendor/github.com/appscode/kutil/core/v1/kubernetes.go
@@ -2,88 +2,13 @@ package v1
 
 import (
 	"github.com/appscode/go/types"
-	"github.com/appscode/kutil/meta"
 	"github.com/appscode/mergo"
 	"github.com/json-iterator/go"
-	"github.com/pkg/errors"
 	core "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/conversion"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 var json = jsoniter.ConfigFastest
-
-func GetGroupVersionKind(v interface{}) schema.GroupVersionKind {
-	return core.SchemeGroupVersion.WithKind(meta.GetKind(v))
-}
-
-func AssignTypeKind(v interface{}) error {
-	_, err := conversion.EnforcePtr(v)
-	if err != nil {
-		return err
-	}
-
-	switch u := v.(type) {
-	case *core.Pod:
-		u.APIVersion = core.SchemeGroupVersion.String()
-		u.Kind = meta.GetKind(v)
-		return nil
-	case *core.ReplicationController:
-		u.APIVersion = core.SchemeGroupVersion.String()
-		u.Kind = meta.GetKind(v)
-		return nil
-	case *core.ConfigMap:
-		u.APIVersion = core.SchemeGroupVersion.String()
-		u.Kind = meta.GetKind(v)
-		return nil
-	case *core.Secret:
-		u.APIVersion = core.SchemeGroupVersion.String()
-		u.Kind = meta.GetKind(v)
-		return nil
-	case *core.Service:
-		u.APIVersion = core.SchemeGroupVersion.String()
-		u.Kind = meta.GetKind(v)
-		return nil
-	case *core.PersistentVolumeClaim:
-		u.APIVersion = core.SchemeGroupVersion.String()
-		u.Kind = meta.GetKind(v)
-		return nil
-	case *core.PersistentVolume:
-		u.APIVersion = core.SchemeGroupVersion.String()
-		u.Kind = meta.GetKind(v)
-		return nil
-	case *core.Node:
-		u.APIVersion = core.SchemeGroupVersion.String()
-		u.Kind = meta.GetKind(v)
-		return nil
-	case *core.ServiceAccount:
-		u.APIVersion = core.SchemeGroupVersion.String()
-		u.Kind = meta.GetKind(v)
-		return nil
-	case *core.Namespace:
-		u.APIVersion = core.SchemeGroupVersion.String()
-		u.Kind = meta.GetKind(v)
-		return nil
-	case *core.Endpoints:
-		u.APIVersion = core.SchemeGroupVersion.String()
-		u.Kind = meta.GetKind(v)
-		return nil
-	case *core.ComponentStatus:
-		u.APIVersion = core.SchemeGroupVersion.String()
-		u.Kind = meta.GetKind(v)
-		return nil
-	case *core.LimitRange:
-		u.APIVersion = core.SchemeGroupVersion.String()
-		u.Kind = meta.GetKind(v)
-		return nil
-	case *core.Event:
-		u.APIVersion = core.SchemeGroupVersion.String()
-		u.Kind = meta.GetKind(v)
-		return nil
-	}
-	return errors.New("unknown v1beta1 object type")
-}
 
 func RemoveNextInitializer(m metav1.ObjectMeta) metav1.ObjectMeta {
 	if m.GetInitializers() != nil {

--- a/vendor/github.com/appscode/kutil/core/v1/pod.go
+++ b/vendor/github.com/appscode/kutil/core/v1/pod.go
@@ -1,6 +1,9 @@
 package v1
 
 import (
+	"bytes"
+	"fmt"
+
 	"github.com/appscode/kutil"
 	"github.com/golang/glog"
 	"github.com/pkg/errors"
@@ -11,6 +14,9 @@ import (
 	"k8s.io/apimachinery/pkg/util/strategicpatch"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/remotecommand"
 )
 
 func CreateOrPatchPod(c kubernetes.Interface, meta metav1.ObjectMeta, transform func(*core.Pod) *core.Pod) (*core.Pod, kutil.VerbType, error) {
@@ -172,4 +178,44 @@ func WaitUntillPodTerminatedByLabel(kubeClient kubernetes.Interface, namespace s
 		}
 		return len(podList.Items) == 0, nil
 	})
+}
+
+func ExecIntoPod(config *rest.Config, pod *core.Pod, command ...string) (string, error) {
+	var (
+		execOut bytes.Buffer
+		execErr bytes.Buffer
+	)
+	kc := kubernetes.NewForConfigOrDie(config)
+
+	req := kc.CoreV1().RESTClient().Post().
+		Resource("pods").
+		Name(pod.Name).
+		Namespace(pod.Namespace).
+		SubResource("exec")
+	req.VersionedParams(&core.PodExecOptions{
+		Container: pod.Spec.Containers[0].Name,
+		Command:   command,
+		Stdout:    true,
+		Stderr:    true,
+	}, scheme.ParameterCodec)
+
+	exec, err := remotecommand.NewSPDYExecutor(config, "POST", req.URL())
+	if err != nil {
+		return "", fmt.Errorf("failed to init executor: %v", err)
+	}
+
+	err = exec.Stream(remotecommand.StreamOptions{
+		Stdout: &execOut,
+		Stderr: &execErr,
+	})
+
+	if err != nil {
+		return "", fmt.Errorf("could not execute: %v", err)
+	}
+
+	if execErr.Len() > 0 {
+		return "", fmt.Errorf("stderr: %v", execErr.String())
+	}
+
+	return execOut.String(), nil
 }

--- a/vendor/github.com/appscode/kutil/discovery/restmapper.go
+++ b/vendor/github.com/appscode/kutil/discovery/restmapper.go
@@ -67,7 +67,7 @@ func guessGVK(obj interface{}) (schema.GroupVersionKind, error) {
 		return schema.GroupVersionKind{}, errors.Errorf("failed to guess GroupVersion from package path %s", pp)
 	}
 	group := parts[len(parts)-2]
-	if strings.HasPrefix(pp, "k8s.io/v1beta1") && group == "core" {
+	if strings.HasPrefix(pp, "k8s.io/api") && group == "core" {
 		group = ""
 	}
 	version := parts[len(parts)-1]

--- a/vendor/github.com/appscode/kutil/extensions/v1beta1/kubernetes.go
+++ b/vendor/github.com/appscode/kutil/extensions/v1beta1/kubernetes.go
@@ -1,47 +1,11 @@
 package v1beta1
 
 import (
-	"github.com/appscode/kutil/meta"
 	"github.com/json-iterator/go"
-	"github.com/pkg/errors"
-	extensions "k8s.io/api/extensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/conversion"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 var json = jsoniter.ConfigFastest
-
-func GetGroupVersionKind(v interface{}) schema.GroupVersionKind {
-	return extensions.SchemeGroupVersion.WithKind(meta.GetKind(v))
-}
-
-func AssignTypeKind(v interface{}) error {
-	_, err := conversion.EnforcePtr(v)
-	if err != nil {
-		return err
-	}
-
-	switch u := v.(type) {
-	case *extensions.Ingress:
-		u.APIVersion = extensions.SchemeGroupVersion.String()
-		u.Kind = meta.GetKind(v)
-		return nil
-	case *extensions.DaemonSet:
-		u.APIVersion = extensions.SchemeGroupVersion.String()
-		u.Kind = meta.GetKind(v)
-		return nil
-	case *extensions.ReplicaSet:
-		u.APIVersion = extensions.SchemeGroupVersion.String()
-		u.Kind = meta.GetKind(v)
-		return nil
-	case *extensions.Deployment:
-		u.APIVersion = extensions.SchemeGroupVersion.String()
-		u.Kind = meta.GetKind(v)
-		return nil
-	}
-	return errors.New("unknown v1beta1 object type")
-}
 
 func IsOwnedByDeployment(references []metav1.OwnerReference) bool {
 	for _, ref := range references {

--- a/vendor/github.com/appscode/kutil/rbac/v1/kubernetes.go
+++ b/vendor/github.com/appscode/kutil/rbac/v1/kubernetes.go
@@ -1,43 +1,7 @@
 package v1
 
 import (
-	"github.com/appscode/kutil/meta"
 	"github.com/json-iterator/go"
-	"github.com/pkg/errors"
-	rbac "k8s.io/api/rbac/v1"
-	"k8s.io/apimachinery/pkg/conversion"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 var json = jsoniter.ConfigFastest
-
-func GetGroupVersionKind(v interface{}) schema.GroupVersionKind {
-	return rbac.SchemeGroupVersion.WithKind(meta.GetKind(v))
-}
-
-func AssignTypeKind(v interface{}) error {
-	_, err := conversion.EnforcePtr(v)
-	if err != nil {
-		return err
-	}
-
-	switch u := v.(type) {
-	case *rbac.Role:
-		u.APIVersion = rbac.SchemeGroupVersion.String()
-		u.Kind = meta.GetKind(v)
-		return nil
-	case *rbac.RoleBinding:
-		u.APIVersion = rbac.SchemeGroupVersion.String()
-		u.Kind = meta.GetKind(v)
-		return nil
-	case *rbac.ClusterRole:
-		u.APIVersion = rbac.SchemeGroupVersion.String()
-		u.Kind = meta.GetKind(v)
-		return nil
-	case *rbac.ClusterRoleBinding:
-		u.APIVersion = rbac.SchemeGroupVersion.String()
-		u.Kind = meta.GetKind(v)
-		return nil
-	}
-	return errors.New("unknown v1beta1 object type")
-}

--- a/vendor/github.com/cenkalti/backoff/backoff.go
+++ b/vendor/github.com/cenkalti/backoff/backoff.go
@@ -15,7 +15,7 @@ import "time"
 // BackOff is a backoff policy for retrying an operation.
 type BackOff interface {
 	// NextBackOff returns the duration to wait before retrying the operation,
-	// or backoff.Stop to indicate that no more retries should be made.
+	// or backoff. Stop to indicate that no more retries should be made.
 	//
 	// Example usage:
 	//

--- a/vendor/github.com/cenkalti/backoff/exponential.go
+++ b/vendor/github.com/cenkalti/backoff/exponential.go
@@ -127,7 +127,9 @@ func (b *ExponentialBackOff) NextBackOff() time.Duration {
 // GetElapsedTime returns the elapsed time since an ExponentialBackOff instance
 // is created and is reset when Reset() is called.
 //
-// The elapsed time is computed using time.Now().UnixNano().
+// The elapsed time is computed using time.Now().UnixNano(). It is
+// safe to call even while the backoff policy is used by a running
+// ticker.
 func (b *ExponentialBackOff) GetElapsedTime() time.Duration {
 	return b.Clock.Now().Sub(b.startTime)
 }

--- a/vendor/github.com/cenkalti/backoff/ticker.go
+++ b/vendor/github.com/cenkalti/backoff/ticker.go
@@ -18,9 +18,12 @@ type Ticker struct {
 	stopOnce sync.Once
 }
 
-// NewTicker returns a new Ticker containing a channel that will send the time at times
-// specified by the BackOff argument. Ticker is guaranteed to tick at least once.
-// The channel is closed when Stop method is called or BackOff stops.
+// NewTicker returns a new Ticker containing a channel that will send
+// the time at times specified by the BackOff argument. Ticker is
+// guaranteed to tick at least once.  The channel is closed when Stop
+// method is called or BackOff stops. It is not safe to manipulate the
+// provided backoff policy (notably calling NextBackOff or Reset)
+// while the ticker is running.
 func NewTicker(b BackOff) *Ticker {
 	c := make(chan time.Time)
 	t := &Ticker{
@@ -29,6 +32,7 @@ func NewTicker(b BackOff) *Ticker {
 		b:    ensureContext(b),
 		stop: make(chan struct{}),
 	}
+	t.b.Reset()
 	go t.run()
 	runtime.SetFinalizer(t, (*Ticker).Stop)
 	return t
@@ -42,7 +46,6 @@ func (t *Ticker) Stop() {
 func (t *Ticker) run() {
 	c := t.c
 	defer close(c)
-	t.b.Reset()
 
 	// Ticker is guaranteed to tick at least once.
 	afterC := t.send(time.Now())

--- a/vendor/github.com/cenkalti/backoff/tries.go
+++ b/vendor/github.com/cenkalti/backoff/tries.go
@@ -3,13 +3,13 @@ package backoff
 import "time"
 
 /*
-WithMaxTries creates a wrapper around another BackOff, which will
+WithMaxRetries creates a wrapper around another BackOff, which will
 return Stop if NextBackOff() has been called too many times since
 the last time Reset() was called
 
 Note: Implementation is not thread-safe.
 */
-func WithMaxTries(b BackOff, max uint64) BackOff {
+func WithMaxRetries(b BackOff, max uint64) BackOff {
 	return &backOffTries{delegate: b, maxTries: max}
 }
 

--- a/vendor/google.golang.org/api/storage/v1/storage-gen.go
+++ b/vendor/google.golang.org/api/storage/v1/storage-gen.go
@@ -222,8 +222,7 @@ type Bucket struct {
 	// when no ACL is provided.
 	DefaultObjectAcl []*ObjectAccessControl `json:"defaultObjectAcl,omitempty"`
 
-	// Encryption: Encryption configuration used by default for newly
-	// inserted objects, when no encryption config is specified.
+	// Encryption: Encryption configuration for a bucket.
 	Encryption *BucketEncryption `json:"encryption,omitempty"`
 
 	// Etag: HTTP 1.1 Entity tag for the bucket.
@@ -405,12 +404,11 @@ func (s *BucketCors) MarshalJSON() ([]byte, error) {
 	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
 }
 
-// BucketEncryption: Encryption configuration used by default for newly
-// inserted objects, when no encryption config is specified.
+// BucketEncryption: Encryption configuration for a bucket.
 type BucketEncryption struct {
 	// DefaultKmsKeyName: A Cloud KMS key that will be used to encrypt
 	// objects inserted into this bucket, if no encryption method is
-	// specified. Limited availability; usable only by enabled projects.
+	// specified.
 	DefaultKmsKeyName string `json:"defaultKmsKeyName,omitempty"`
 
 	// ForceSendFields is a list of field names (e.g. "DefaultKmsKeyName")


### PR DESCRIPTION
Stash will wait to connect to the apiserver until the delay expires. The default is set to forever as it's reasonable to expect that the apiserver will come back; until it doesn't the restore pod has nothing else to do, really.

Fixes #475