### PR TITLE
Add app: stash label to user roles.

### DIFF
--- a/hack/deploy/user-roles.yaml
+++ b/hack/deploy/user-roles.yaml
@@ -3,6 +3,7 @@ kind: ClusterRole
 metadata:
   name: appscode:stash:edit
   labels:
+    app: stash
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
 rules:
@@ -27,6 +28,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: appscode:stash:view
   labels:
+    app: stash
     rbac.authorization.k8s.io/aggregate-to-view: "true"
 rules:
 - apiGroups:


### PR DESCRIPTION
This ensures that these roles are deleted when stash is uninstalled.