### PR TITLE
Delete user roles on purge.

### DIFF
--- a/hack/deploy/stash.sh
+++ b/hack/deploy/stash.sh
@@ -257,6 +257,9 @@ if [ "$STASH_UNINSTALL" -eq 1 ]; then
             # delete crd
             kubectl delete crd ${crd}.stash.appscode.com || true
         done
+
+        # delete user roles
+        kubectl delete clusterroles appscode:stash:edit appscode:stash:view
     fi
 
     echo


### PR DESCRIPTION
We can't use labels to delete user roles, since that will remove user permission in simple uninstall (w/o --purge flag).