### PR TITLE
Don't use priority class when operator namespace is not kube-system

### DIFF
--- a/hack/deploy/operator.yaml
+++ b/hack/deploy/operator.yaml
@@ -94,7 +94,7 @@ spec:
       tolerations:
       - key: CriticalAddonsOnly
         operator: Exists
-      priorityClassName: system-cluster-critical
+      priorityClassName: ${STASH_PRIORITY_CLASS}
 ---
 # kube lacks the service serving cert signer, so provide a manual secret for it
 apiVersion: v1

--- a/hack/deploy/stash.sh
+++ b/hack/deploy/stash.sh
@@ -122,6 +122,7 @@ export STASH_UNINSTALL=0
 export STASH_PURGE=0
 export STASH_BYPASS_VALIDATING_WEBHOOK_XRAY=false
 export STASH_USE_KUBEAPISERVER_FQDN_FOR_AKS=true
+export STASH_PRIORITY_CLASS=system-cluster-critical
 
 export SCRIPT_LOCATION="curl -fsSL https://raw.githubusercontent.com/appscode/stash/0.8.2/"
 if [[ "$APPSCODE_ENV" == "dev" ]]; then
@@ -324,6 +325,10 @@ while test $# -gt 0; do
 done
 
 export PROMETHEUS_NAMESPACE=${PROMETHEUS_NAMESPACE:-$STASH_NAMESPACE}
+
+if [ "$STASH_NAMESPACE" != "kube-system" ]; then
+    export STASH_PRIORITY_CLASS=""
+fi
 
 if [ "$STASH_UNINSTALL" -eq 1 ]; then
   # delete webhooks and apiservices


### PR DESCRIPTION
Fixes: https://github.com/appscode/stash/issues/665