### PR TITLE
Implement snapshots for v1beta1 api

### DIFF
--- a/pkg/cmds/cli/cli.go
+++ b/pkg/cmds/cli/cli.go
@@ -1,11 +1,16 @@
 package cli
 
 import (
+	"io/ioutil"
+	"os"
 	"path/filepath"
 
 	cs "github.com/appscode/stash/client/clientset/versioned"
+	"github.com/appscode/stash/pkg/cmds/docker"
 	docker_image "github.com/appscode/stash/pkg/docker"
+	"github.com/appscode/stash/pkg/restic"
 	"github.com/spf13/cobra"
+	core "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/util/homedir"
@@ -77,4 +82,49 @@ func newStashCLIController(kubeConfig string) (*stashCLIController, error) {
 		return nil, err
 	}
 	return controller, nil
+}
+
+func (localDirs *cliLocalDirectories) prepareSecretDir(tempDir string, secret *core.Secret) error {
+	// write repository secrets in a sub-dir insider tempDir
+	localDirs.secretDir = filepath.Join(tempDir, secretDirName)
+	if err := os.MkdirAll(localDirs.secretDir, 0755); err != nil {
+		return err
+	}
+	for key, value := range secret.Data {
+		if err := ioutil.WriteFile(filepath.Join(localDirs.secretDir, key), value, 0755); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (localDirs *cliLocalDirectories) prepareConfigDir(tempDir string, setupOpt *restic.SetupOptions, restoreOpt *restic.RestoreOptions) error {
+	// write restic options in a sub-dir insider tempDir
+	localDirs.configDir = filepath.Join(tempDir, configDirName)
+	if err := os.MkdirAll(localDirs.secretDir, 0755); err != nil {
+		return err
+	}
+	if setupOpt != nil {
+		err := docker.WriteSetupOptionToFile(setupOpt, filepath.Join(localDirs.configDir, docker.SetupOptionsFile))
+		if err != nil {
+			return err
+		}
+	}
+	if restoreOpt != nil {
+		err := docker.WriteRestoreOptionToFile(restoreOpt, filepath.Join(localDirs.configDir, docker.RestoreOptionsFile))
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (localDirs *cliLocalDirectories) prepareDownloadDir() (err error) {
+	// if destination flag is not specified, restore in current directory
+	if localDirs.downloadDir == "" {
+		if localDirs.downloadDir, err = os.Getwd(); err != nil {
+			return err
+		}
+	}
+	return os.MkdirAll(localDirs.downloadDir, 0755)
 }

--- a/pkg/cmds/cli/cli.go
+++ b/pkg/cmds/cli/cli.go
@@ -14,14 +14,20 @@ import (
 )
 
 const (
-	cliSecretDir  = "/tmp/stash-cli/secret"
-	cliConfigDir  = "/tmp/stash-cli/config"
+	secretDirName = "secret"
+	configDirName = "config"
 )
 
 type stashCLIController struct {
 	clientConfig *rest.Config
 	kubeClient   kubernetes.Interface
 	stashClient  cs.Interface
+}
+
+type cliLocalDirectories struct {
+	secretDir   string // temp dir
+	configDir   string // temp dir
+	downloadDir string // user provided or, current working dir
 }
 
 var (

--- a/pkg/cmds/cli/cli.go
+++ b/pkg/cmds/cli/cli.go
@@ -60,6 +60,7 @@ func NewCLICmd() *cobra.Command {
 	cmd.AddCommand(NewTriggerBackupCmd())
 	cmd.AddCommand(NewBackupPVCmd())
 	cmd.AddCommand(NewDownloadCmd())
+	cmd.AddCommand(NewDeleteSnapshotCmd())
 
 	return cmd
 }

--- a/pkg/cmds/cli/unlock_repository.go
+++ b/pkg/cmds/cli/unlock_repository.go
@@ -109,8 +109,8 @@ func NewUnlockRepositoryCmd() *cobra.Command {
 	cmd.Flags().StringVar(&repositoryName, "repository", repositoryName, "Name of the Repository.")
 	cmd.Flags().StringVar(&namespace, "namespace", "default", "Namespace of the Repository.")
 
-	cmd.Flags().StringVar(&image.Registry, "docker-registry", image.Registry, "Docker image registry for unlock job")
-	cmd.Flags().StringVar(&image.Tag, "image-tag", image.Tag, "Stash image tag for unlock job")
+	cmd.Flags().StringVar(&image.Registry, "docker-registry", image.Registry, "Docker image registry")
+	cmd.Flags().StringVar(&image.Tag, "image-tag", image.Tag, "Stash image tag")
 
 	return cmd
 }

--- a/pkg/cmds/docker/delete_snapshot.go
+++ b/pkg/cmds/docker/delete_snapshot.go
@@ -1,0 +1,37 @@
+package docker
+
+import (
+	"path/filepath"
+
+	"github.com/appscode/go/log"
+	"github.com/appscode/stash/pkg/restic"
+	"github.com/spf13/cobra"
+)
+
+func NewDeleteSnapshotCmd() *cobra.Command {
+	var snapshotID string
+	var cmd = &cobra.Command{
+		Use:               "delete-snapshot",
+		Short:             `Delete a snapshot from repository backend`,
+		Long:              `Delete a snapshot from repository backend`,
+		DisableAutoGenTag: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			setupOpt, err := ReadSetupOptionFromFile(filepath.Join(ConfigDir, SetupOptionsFile))
+			if err != nil {
+				return err
+			}
+			resticWrapper, err := restic.NewResticWrapper(*setupOpt)
+			if err != nil {
+				return err
+			}
+			// delete snapshots
+			if _, err = resticWrapper.DeleteSnapshots([]string{snapshotID}); err != nil {
+				return err
+			}
+			log.Infof("Delete completed")
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&snapshotID, "snapshot", snapshotID, "Snapshot ID to be deleted")
+	return cmd
+}

--- a/pkg/cmds/docker/docker.go
+++ b/pkg/cmds/docker/docker.go
@@ -32,6 +32,7 @@ func NewDockerCmd() *cobra.Command {
 
 	cmd.AddCommand(NewUnlockRepositoryCmd())
 	cmd.AddCommand(NewDownloadCmd())
+	cmd.AddCommand(NewDeleteSnapshotCmd())
 
 	return cmd
 }

--- a/pkg/cmds/forget.go
+++ b/pkg/cmds/forget.go
@@ -39,11 +39,7 @@ func NewCmdForget() *cobra.Command {
 			}
 
 			r := snapshot.NewREST(config)
-			err = r.ForgetSnapshots(repo, args)
-			if err != nil {
-				return err
-			}
-			return nil
+			return r.ForgetVersionedSnapshots(repo, args, true)
 		},
 	}
 	cmd.Flags().StringVar(&masterURL, "master", masterURL, "The address of the Kubernetes API server (overrides any value in kubeconfig)")

--- a/pkg/cmds/snapshot.go
+++ b/pkg/cmds/snapshot.go
@@ -40,7 +40,7 @@ func NewCmdSnapshots() *cobra.Command {
 			}
 
 			r := snapshot.NewREST(config)
-			snapshots, err := r.GetSnapshots(repo, args)
+			snapshots, err := r.GetVersionedSnapshots(repo, args, true)
 			if err != nil {
 				return err
 			}

--- a/pkg/registry/snapshot/snapshot.go
+++ b/pkg/registry/snapshot/snapshot.go
@@ -79,7 +79,7 @@ func (r *REST) Get(ctx context.Context, name string, options *metav1.GetOptions)
 		}
 	}
 
-	snapshots, err := r.getVersionedSnapshots(repo, []string{snapshotId})
+	snapshots, err := r.GetVersionedSnapshots(repo, []string{snapshotId}, false)
 	if err != nil {
 		return nil, apierrors.NewInternalError(err)
 	}
@@ -129,7 +129,7 @@ func (r *REST) List(ctx context.Context, options *metainternalversion.ListOption
 		Items: make([]repositories.Snapshot, 0),
 	}
 	for _, repo := range selectedRepos {
-		snapshots, err := r.getVersionedSnapshots(&repo, nil)
+		snapshots, err := r.GetVersionedSnapshots(&repo, nil, false)
 		if err != nil {
 			return nil, apierrors.NewInternalError(err)
 		}
@@ -160,14 +160,14 @@ func (r *REST) Delete(ctx context.Context, name string, options *metav1.DeleteOp
 	}
 
 	// first, check if the snapshot exist
-	snapshots, err := r.getVersionedSnapshots(repo, []string{snapshotId})
+	snapshots, err := r.GetVersionedSnapshots(repo, []string{snapshotId}, false)
 	if err != nil {
 		return nil, false, apierrors.NewInternalError(err)
 	} else if len(snapshots) == 0 {
 		return nil, false, apierrors.NewNotFound(repositories.Resource(repov1alpha1.ResourceSingularSnapshot), name)
 	}
 	// delete snapshot
-	if err = r.deleteVersionedSnapshots(repo, []string{snapshotId}); err != nil {
+	if err = r.ForgetVersionedSnapshots(repo, []string{snapshotId}, false); err != nil {
 		return nil, false, apierrors.NewInternalError(err)
 	}
 

--- a/pkg/registry/snapshot/snapshot.go
+++ b/pkg/registry/snapshot/snapshot.go
@@ -19,6 +19,7 @@ import (
 	"k8s.io/apiserver/pkg/registry/rest"
 	"k8s.io/client-go/kubernetes"
 	restconfig "k8s.io/client-go/rest"
+	core_util "kmodules.xyz/client-go/core/v1"
 )
 
 type REST struct {
@@ -78,20 +79,15 @@ func (r *REST) Get(ctx context.Context, name string, options *metav1.GetOptions)
 		}
 	}
 
-	snapshots := make([]repositories.Snapshot, 0)
-	if repo.Spec.Backend.Local != nil {
-		snapshots, err = r.getSnapshotsFromSidecar(repo, []string{snapshotId})
-	} else {
-		snapshots, err = r.GetSnapshots(repo, []string{snapshotId})
-	}
+	snapshots, err := r.getVersionedSnapshots(repo, []string{snapshotId})
 	if err != nil {
 		return nil, apierrors.NewInternalError(err)
 	}
-
 	if len(snapshots) == 0 {
 		return nil, apierrors.NewNotFound(repositories.Resource(repov1alpha1.ResourceSingularSnapshot), name)
 	}
 
+	// TODO: return &snapshots[0], nil
 	snapshot := &repositories.Snapshot{}
 	snapshot = &snapshots[0]
 	return snapshot, nil
@@ -115,9 +111,12 @@ func (r *REST) List(ctx context.Context, options *metainternalversion.ListOption
 	var selectedRepos []stash.Repository
 	if options.LabelSelector != nil {
 		for _, r := range repos.Items {
-			repoLabels := make(map[string]string)
-			repoLabels = r.Labels
-			repoLabels["repository"] = r.Name
+			repoLabels := map[string]string{
+				"repository": r.Name,
+			}
+			if r.Labels != nil {
+				repoLabels = core_util.UpsertMap(repoLabels, r.Labels)
+			}
 			if options.LabelSelector.Matches(labels.Set(repoLabels)) {
 				selectedRepos = append(selectedRepos, r)
 			}
@@ -130,17 +129,9 @@ func (r *REST) List(ctx context.Context, options *metainternalversion.ListOption
 		Items: make([]repositories.Snapshot, 0),
 	}
 	for _, repo := range selectedRepos {
-		var snapshots []repositories.Snapshot
-		if repo.Spec.Backend.Local != nil {
-			snapshots, err = r.getSnapshotsFromSidecar(&repo, nil)
-			if err != nil {
-				return nil, apierrors.NewInternalError(err)
-			}
-		} else {
-			snapshots, err = r.GetSnapshots(&repo, nil)
-			if err != nil {
-				return nil, apierrors.NewInternalError(err)
-			}
+		snapshots, err := r.getVersionedSnapshots(&repo, nil)
+		if err != nil {
+			return nil, apierrors.NewInternalError(err)
 		}
 		snapshotList.Items = append(snapshotList.Items, snapshots...)
 	}
@@ -169,26 +160,14 @@ func (r *REST) Delete(ctx context.Context, name string, options *metav1.DeleteOp
 	}
 
 	// first, check if the snapshot exist
-	snapshots := make([]repositories.Snapshot, 0)
-	if repo.Spec.Backend.Local != nil {
-		snapshots, err = r.getSnapshotsFromSidecar(repo, []string{snapshotId})
-	} else {
-		snapshots, err = r.GetSnapshots(repo, []string{snapshotId})
-	}
-
+	snapshots, err := r.getVersionedSnapshots(repo, []string{snapshotId})
 	if err != nil {
 		return nil, false, apierrors.NewInternalError(err)
 	} else if len(snapshots) == 0 {
 		return nil, false, apierrors.NewNotFound(repositories.Resource(repov1alpha1.ResourceSingularSnapshot), name)
 	}
-
 	// delete snapshot
-	if repo.Spec.Backend.Local != nil {
-		err = r.forgetSnapshotsFromSidecar(repo, []string{snapshotId})
-	} else {
-		err = r.ForgetSnapshots(repo, []string{snapshotId})
-	}
-	if err != nil {
+	if err = r.deleteVersionedSnapshots(repo, []string{snapshotId}); err != nil {
 		return nil, false, apierrors.NewInternalError(err)
 	}
 


### PR DESCRIPTION
fixes #738 

- [x] Fix nil pointer error
- [x] Get/Delete snapshots for based on version
- [x] Get/Delete snapshots for local backends (sidecar model)
- [ ] Get/Delete snapshots for local backends (function/task model)
- [ ] Add `backup-config`, `workload-kind`, `workload-name` labels to repository (like v1alpha)
- [x] TImeout processing remote repositories - Delete command will be moved to CLI. List/Get will be left as EAS for now.